### PR TITLE
Make mnemonics in the menu bar visible in bare Linux ttys

### DIFF
--- a/internal/tui/menu/menu.go
+++ b/internal/tui/menu/menu.go
@@ -2,6 +2,9 @@ package menu
 
 import (
 	"dinky/internal/tui/utils"
+	"fmt"
+	"os"
+	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
@@ -80,20 +83,31 @@ func (menuBar *MenuBar) Draw(screen tcell.Screen) {
 	reverse := menuBar.MenuBarStyle.Foreground(bg).Background(fg)
 
 	dx := 0
+	isLinuxTerm := os.Getenv("TERM") == "linux"
 	for i, menu := range menuBar.menus {
 		title := menu.Title
 		style := menuBar.MenuBarStyle
-		if i == menuBar.selectedPath[0] {
+		isSelected := i == menuBar.selectedPath[0]
+		if isSelected {
 			style = reverse
+		} else if isLinuxTerm {
+			// In bare Linux TTYs, underline is often emulated by color 4 (Blue).
+			// If the menu bar background is Blue, underlined mnemonics become invisible.
+			// We fix this by using a different color (Yellow) and removing the underline attribute.
+			title = strings.ReplaceAll(title, "[::u]", "[yellow]")
+			title = strings.ReplaceAll(title, "[::U]", "[-]")
 		}
 		utils.DrawText(screen, dx, y, padding, style)
 		dx += MENU_BAR_PADDING
 
-		color, _, _ := style.Decompose()
+		color, bg, _ := style.Decompose()
+		r, g, b := bg.RGB()
+		taggedTitle := fmt.Sprintf("[:#%02x%02x%02x:]%s", r, g, b, title)
+
 		// First measure the width
-		_, titleWidth := tview.Print(screen, title, dx, y, width, tview.AlignLeft, color)
+		_, titleWidth := tview.Print(screen, taggedTitle, dx, y, width, tview.AlignLeft, color)
 		utils.DrawSpace(screen, dx, y, titleWidth, style)
-		tview.Print(screen, title, dx, y, width, tview.AlignLeft, color)
+		tview.Print(screen, taggedTitle, dx, y, width, tview.AlignLeft, color)
 		dx += titleWidth
 		menu.charWidth = titleWidth
 


### PR DESCRIPTION
In bare Linux ttys, underlines are not displayed and are "emulated" by setting the background color to blue. In Dinky, this makes the underlined mnemonic characters in the menu bar invisible when in a bare tty. This PR makes it so that, when in a bare Linux tty, the mnemonics in the menu bar will use a yellow foreground with no underline attribute, making the mnemonics visible and preventing the underline emulation from controlling color.

This new behavior is only triggered when `TERM=linux`, so Dinky should continue behaving identically in graphical terminal emulators.