### PR TITLE
Make error loading file dialog auto-focus

### DIFF
--- a/internal/application/dinky.go
+++ b/internal/application/dinky.go
@@ -670,12 +670,13 @@ func Main() {
 			ShowOkDialog("Error loading file", errorMessage, showLoadingError)
 		}
 	}
-	showLoadingError()
-
 	if len(fileBuffers) == 0 {
 		newFile("", "")
 	}
 	selectTab(fileBuffers[0].uuid)
+
+	// Shown after the tabs are set up so the dialog keeps focus.
+	showLoadingError()
 
 	// Track the mouse position (used by the GPM cursor renderer) and turn
 	// horizontal wheel events into horizontal scrolling of the editor. The

--- a/internal/application/messagedialog.go
+++ b/internal/application/messagedialog.go
@@ -71,6 +71,9 @@ func ShowMessageDialog(title string, message string, buttons []string, OnClose f
 	messageDialog.OnButtonClick = OnButtonClick
 	messageDialog.Open(title, message, buttons, width, height)
 	style.StyleMessageDialog(messageDialog)
+	// AddPage focuses the dialog before Open() has created the buttons, so focus
+	// the first button explicitly now that they exist.
+	app.SetFocus(messageDialog)
 
 	return messageDialog
 }


### PR DESCRIPTION
This PR makes the "error loading file" dialog auto-focus. There was previously no way to close it without a mouse.